### PR TITLE
feat: run on SAP BTP Cloud Foundry with XSUAA and principal propagation

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,9 @@
+.git/
+node_modules/
+src/
+tests/
+scripts/
+docs/
+payloads/
+tsconfig.json
+*.md

--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,9 @@ payloads/
 playbooks/
 notes/
 tests/
+# …but track the checked-in test suite. `tests/` stays ignored as a scratch area;
+# only these files are versioned.
+!tests/*.test.mjs
 poc/
 .claude/
 CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ A Model Context Protocol (MCP) server that enables AI assistants like Claude to 
 
 ---
 
+## ☁️ Running on SAP BTP Cloud Foundry
+
+Besides stdio, the server can run as an HTTP service on SAP BTP Cloud Foundry with XSUAA
+OAuth in front and a BTP destination behind — either a shared technical user
+(`BasicAuthentication`) or **principal propagation**, where each caller reaches BW as
+themselves and BW applies their own authorizations.
+
+Two role collections decide what a user is offered: **BW MCP Reader** (the 41 read tools)
+and **BW MCP Developer** (all 83). Setup: [docs/CLOUD-FOUNDRY.md](docs/CLOUD-FOUNDRY.md).
+
+stdio is unchanged — `npm start` behaves exactly as before.
+
+---
+
 ## 📖 Featured Blog Post
 
 **Agentic AI meets SAP BW** — the full story behind this project: why I built it, what's inside, what happens when Claude walks through a complete BW data lineage on its own.

--- a/docs/CLOUD-FOUNDRY.md
+++ b/docs/CLOUD-FOUNDRY.md
@@ -1,0 +1,160 @@
+# Running on SAP BTP Cloud Foundry
+
+The stdio server is single-user: whoever runs it supplies `BW_USER` / `BW_PASSWORD`, and
+that is the identity BW sees. This guide covers the HTTP transport, which serves several
+users over the network with OAuth at the front and a BTP destination at the back.
+
+Nothing here changes stdio. `npm start` behaves exactly as before.
+
+## Two topologies
+
+Pick by how you configure the BTP destination:
+
+| | **Shared technical user** | **Principal propagation** |
+|---|---|---|
+| Destination | `Authentication=BasicAuthentication` | `Authentication=PrincipalPropagation` |
+| Env | — | `BW_PP_ENABLED=true` |
+| BW sees | the destination's user, for everyone | each caller as themselves |
+| Per-user control | MCP scopes only | MCP scopes **and** the user's own BW authorizations |
+| Setup effort | destination only | Cloud Connector certificates + ABAP CERTRULE + ICM trust |
+
+Start with the shared user to get the deployment working, then switch on principal
+propagation. Both use the same image and the same role collections.
+
+## 1. Roles
+
+Two role collections ship in `xs-security.json`:
+
+| Collection | Scope | Gets |
+|---|---|---|
+| **BW MCP Reader** | `read` | the 41 read tools |
+| **BW MCP Developer** | `read` + `write` | all 83 |
+
+A reader does not merely get errors from the write tools — they are filtered out of
+`tools/list`, so the model never proposes a call that will be denied.
+
+The split follows the HTTP verb each tool actually uses, not its name: `bw_query_data`
+and `bw_preview_datasource` issue POSTs but only read, while `bw_unlock` sounds harmless
+and mutates lock state. Anything not on the read list requires `write`, so a tool added
+later is unavailable to readers until it is classified.
+
+Under principal propagation the scope is only the first gate — BW still applies the
+caller's own authorizations. Under a shared technical user the scope is the *only*
+per-user control, which is worth weighing when handing out **BW MCP Developer**.
+
+## 2. Deploy
+
+```bash
+cf create-service xsuaa        application bwmcp-xsuaa -c xs-security.json
+cf create-service destination  lite        bwmcp-destination
+cf create-service connectivity lite        bwmcp-connectivity   # on-premise BW only
+
+npm ci && npm run build      # dist/ is what ships; .cfignore excludes src/
+cf push                      # set BW_BTP_DESTINATION and BW_CLIENT in manifest.yml first
+```
+
+```bash
+btp assign security/role-collection "BW MCP Developer" --to-user <email> --of-idp <idp>
+```
+
+Use the identity provider the application actually logs in through — on a subaccount with
+a custom IAS tenant that is `sap.custom`, not `sap.default`. The wrong one fails with
+`invalid_scope` and no other clue.
+
+Point an MCP client at `https://<app-route>/mcp`. OAuth is discoverable, so that URL is
+all a client needs: it finds the authorization server, registers itself, and sends the
+user through the normal browser login.
+
+## 3. Principal propagation
+
+Only needed for per-user identity. The chain:
+
+```
+MCP client --XSUAA JWT--> this app --X-User-Token--> Destination service
+   --SAP-Connectivity-Authentication--> Cloud Connector
+   --short-lived X.509 in SSL_CLIENT_CERT--> BW  --CERTRULE--> ABAP user
+```
+
+**Cloud Connector**
+
+1. **System certificate** — the connector's own TLS identity. Self-signed ones must have
+   no Subject Alternative Names.
+2. **CA certificate** — signs the per-user certificates; needs the `keyCertSign` usage.
+   *A different certificate from the system one.* Configuring only the latter gives
+   `IllegalStateException: No CA certificate available`.
+3. **Principal Propagation** → subject pattern, e.g. `CN=${login_name}`, then
+   **Generate Sample Certificate** — CERTRULE needs that file.
+4. **Backend Trust Store** → add the CA of BW's own server certificate.
+5. **Cloud to On-Premises → Principal Propagation → Synchronize**, and mark the identity
+   provider **Trusted**. That list is empty by default.
+6. **Access control entry**: Protocol HTTPS, *Allow Principal Propagation* ✓, Principal
+   Type **X.509 Certificate**.
+7. **Expose the resources** — a step separate from the system mapping, and easily missed:
+   `/sap/bw/modeling`, `/sap/bw4`, `/sap/bc/http/sap/bw4`, `/sap/opu/odata/sap`, each with
+   *Path and all sub-paths*. A mapping created earlier for ADT exposes only `/sap/bc/adt`.
+
+**ABAP**
+
+8. **STRUST** → SSL server Standard → import the **issuer** of the system certificate.
+9. `icm/trusted_reverse_proxy_<x> = SUBJECT="<subj>", ISSUER="<iss>"` — uppercase
+   keywords; below kernel 7.53 the DN needs a blank after each comma even though the
+   connector UI shows none. The older `icm/HTTPS/trust_client_with_issuer` /
+   `..._with_subject` pair is for kernel ≤ 7.42, and **setting both variants means both
+   are ignored** (SAP Note 2052899) — a silent, total loss of trust.
+10. `icm/HTTPS/verify_client = 1`; the per-port `VCLIENT=` overrides it, and `VCLIENT=0`
+    breaks propagation.
+11. `login/certificate_mapping_rulebased = 1`, after migrating any USREXTID entries with
+    `CERTRULE_MIG`.
+12. **CERTRULE** → import the sample certificate, create the rule. It is
+    **client-dependent**. Map to **Alias** or **E-Mail**, never **User Name** — ABAP user
+    names are 12 characters and BTP identities are email addresses.
+13. **SICF** → the BW paths must allow *Logon Through SSL Certificate*.
+14. **SMICM** → Administration → ICM → Exit Hard → Global.
+
+SNC is not involved — that is the RFC propagation path, not HTTPS.
+
+## 4. The destination
+
+| Property | Value |
+|---|---|
+| `Type` | `HTTP` |
+| `URL` | `http://<cc-virtual-host>:<port>` for on-premise — **`http://`, see below** |
+| `ProxyType` | `OnPremise` (via Cloud Connector) or `Internet` |
+| `Authentication` | `PrincipalPropagation` or `BasicAuthentication` |
+| `CloudConnectorLocationId` | only if several connectors serve the subaccount |
+
+> **The `https://` trap.** SAP: *"the call from the cloud application must always use
+> HTTP. If HTTPS is used, a 405 response will be returned."* An `https://` destination
+> also makes the HTTP client tunnel with `CONNECT`, which drops the proxy and identity
+> headers before the proxy sees them — so the 405 says nothing about the real cause. The
+> Cloud Connector still reaches BW over HTTPS. The server rejects this configuration up
+> front rather than letting you debug the 405.
+
+## 5. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `502 Could not connect to BW` | destination lookup or propagation failed | the message says which; check the destination name and binding |
+| 401 + basic-auth popup; ICM trace `intermediary is NOT trusted` | ICM stripped `SSL_CLIENT_CERT` | step 9 — missing, mistyped, lowercase keyword, wrong spacing, or both variants set |
+| `403 Access denied to resource … expose the resource correctly in your cloud connector` | path not exposed | step 7 — a Cloud Connector message, not an authorization failure |
+| `invalid_scope` at login | role collection assigned under the wrong identity provider | re-assign with the right `--of-idp` |
+| First call takes ~70 s | BW initializes each ICF handler on first use | expected; sub-second afterwards. `/health` does not touch BW |
+
+Traces: SMICM → Goto → Trace → Level 2; Cloud Connector loggers to All/Debug. SAP guides:
+KBA **3361376259** (propagation over HTTPS), **3367280** (401 / credential popup),
+**3371621** (common ICM parameter mistakes).
+
+## Environment variables
+
+| Variable | Meaning |
+|---|---|
+| `BW_BTP_DESTINATION` | destination name (required for HTTP) |
+| `BW_PP_ENABLED` | `true` to use principal propagation |
+| `BW_CLIENT`, `BW_LANGUAGE` | as for stdio |
+| `BW_CC_LOCATION_ID` | Cloud Connector location id, when several are connected |
+| `BW_PUBLIC_URL` | advertised URL behind a reverse proxy |
+| `BW_ALLOWED_ORIGINS` | CORS allowlist for browser-based MCP clients |
+
+With `BW_PP_ENABLED=true` the server refuses to start if `BW_USER`, `BW_PASSWORD` or
+`BW_COOKIE_FILE` is also set: BW ties a session to whoever opened it, so one leftover
+shared credential would silently override every per-user identity.

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,40 @@
+---
+# SAP BTP Cloud Foundry deployment.
+#
+# Two supported topologies, chosen by the destination:
+#   Authentication=PrincipalPropagation + BW_PP_ENABLED=true  -> each user reaches BW as
+#     themselves; BW applies their own authorizations.
+#   Authentication=BasicAuthentication  + BW_PP_ENABLED unset -> all users share the
+#     destination's technical user; the MCP scopes are the only per-user control.
+#
+# See docs/CLOUD-FOUNDRY.md for the full setup.
+applications:
+  - name: bw-modeling-mcp
+    memory: 512M
+    disk_quota: 1G
+    instances: 1
+    buildpacks:
+      - nodejs_buildpack
+    command: npm run start:http
+    health-check-type: http
+    health-check-http-endpoint: /health
+    env:
+      NODE_ENV: production
+      # BTP destination pointing at the BW system.
+      BW_BTP_DESTINATION: "BW4"
+      BW_CLIENT: "100"
+      BW_LANGUAGE: "EN"
+      # Per-user identity via Cloud Connector principal propagation. Requires CERTRULE
+      # and ICM trust on the ABAP side — see docs/CLOUD-FOUNDRY.md §3.
+      # BW_PP_ENABLED: "true"
+      # Only when several Cloud Connectors serve this subaccount.
+      # BW_CC_LOCATION_ID: "bw-prod"
+      # Public route, if behind a reverse proxy that rewrites Host.
+      # BW_PUBLIC_URL: "https://bw-modeling-mcp.example.com"
+      # CORS, only for browser-based MCP clients. Native clients do not need it.
+      # BW_ALLOWED_ORIGINS: "https://claude.ai"
+    services:
+      - bwmcp-xsuaa
+      - bwmcp-destination
+      # Only needed for an on-premise BW behind the Cloud Connector.
+      - bwmcp-connectivity

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@arc-mcp/xsuaa-auth": "^0.1.8",
+        "@arc-mcp/xsuaa-auth": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.7.0",
         "express": "^5.2.1",
         "fast-xml-parser": "^4.3.0"
       },
       "bin": {
-        "bw-modeling-mcp": "dist/index.js"
+        "bw-modeling-mcp": "dist/stdio.js"
       },
       "devDependencies": {
         "@types/express": "^5.0.6",
@@ -24,13 +24,13 @@
         "typescript": "^5.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@arc-mcp/xsuaa-auth": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@arc-mcp/xsuaa-auth/-/xsuaa-auth-0.1.8.tgz",
-      "integrity": "sha512-ufRgPNLH3zAfzObLqfau8JNzfvowA0qSmY6i+lk1HOJFUVopN4gYtbpZqwt6fBBQaJobjno/w7QkXd0YTH3tig==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@arc-mcp/xsuaa-auth/-/xsuaa-auth-1.0.0.tgz",
+      "integrity": "sha512-2586hvCp5slpvWsHIvPSjHDw0LUqGCcG0tVtEPYPq+W6coifv2/z+WvEWpLPQSLS23BLfFjxHKW5SdgV8zs3aw==",
       "license": "MIT",
       "dependencies": {
         "@sap-cloud-sdk/connectivity": "^4.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,65 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@arc-mcp/xsuaa-auth": "^0.1.8",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "axios": "^1.7.0",
+        "express": "^5.2.1",
         "fast-xml-parser": "^4.3.0"
       },
       "bin": {
         "bw-modeling-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@types/express": "^5.0.6",
         "@types/node": "^20.0.0",
         "typescript": "^5.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@arc-mcp/xsuaa-auth": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@arc-mcp/xsuaa-auth/-/xsuaa-auth-0.1.8.tgz",
+      "integrity": "sha512-ufRgPNLH3zAfzObLqfau8JNzfvowA0qSmY6i+lk1HOJFUVopN4gYtbpZqwt6fBBQaJobjno/w7QkXd0YTH3tig==",
+      "license": "MIT",
+      "dependencies": {
+        "@sap-cloud-sdk/connectivity": "^4.7.0",
+        "@sap/xssec": "^4.13.3"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": ">=1.18.2 <2",
+        "express": "^5.0.1",
+        "jose": ">=5 <7"
+      },
+      "peerDependenciesMeta": {
+        "jose": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -36,9 +82,10 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -74,6 +121,138 @@
         }
       }
     },
+    "node_modules/@sap-cloud-sdk/connectivity": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/connectivity/-/connectivity-4.8.0.tgz",
+      "integrity": "sha512-y8H0AKgDecm7+A8wxx+J1oxJTzYEs+4Hy7ghfrBD57e9MdRRFI5FryYqokZbDcMjEnsbvZ+giShm/A2UXmeHyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sap-cloud-sdk/resilience": "^4.8.0",
+        "@sap-cloud-sdk/util": "^4.8.0",
+        "@sap/xsenv": "^6.2.0",
+        "@sap/xssec": "^4.13.0",
+        "async-retry": "^1.3.3",
+        "axios": "^1.15.0",
+        "jks-js": "^1.1.6",
+        "jsonwebtoken": "^9.0.3",
+        "safe-stable-stringify": "^2.5.0"
+      }
+    },
+    "node_modules/@sap-cloud-sdk/resilience": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/resilience/-/resilience-4.8.0.tgz",
+      "integrity": "sha512-/XclOtUHhdN39acKH1otJdMILAm+HJkQ6wjpUvqBx7RNiQ1GQwe34qSqy8wGDJr5MbcxuhENYGWJRLE4P4OHqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sap-cloud-sdk/util": "^4.8.0",
+        "async-retry": "^1.3.3",
+        "axios": "^1.15.0",
+        "opossum": "^10.0.0"
+      }
+    },
+    "node_modules/@sap-cloud-sdk/util": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@sap-cloud-sdk/util/-/util-4.8.0.tgz",
+      "integrity": "sha512-wLWxgxYwAL1N5dh+m8XGZTZ2vzooDHXKXrkay3rBpYSFHhZjsD2V37ezbAhbBKlFIELZA03C+Eb9o4YgHpvTKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "axios": "^1.15.0",
+        "logform": "^2.7.0",
+        "voca": "^1.4.1",
+        "winston": "^3.19.0",
+        "winston-transport": "^4.9.0"
+      }
+    },
+    "node_modules/@sap/xsenv": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@sap/xsenv/-/xsenv-6.2.1.tgz",
+      "integrity": "sha512-R1p7VdD3N3jvdkL8av4vLqF+cTQihTz9mCqqF+oa9rVZvgLaCb4ODyZ1dln5/fBgg1OSuch0ESxu3AqZrXVknw==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "debug": "4.4.3",
+        "node-cache": "^5.1.2",
+        "verror": "1.10.1"
+      },
+      "engines": {
+        "node": "^20.0.0  || ^22.0.0 || ^24.0.0"
+      }
+    },
+    "node_modules/@sap/xssec": {
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/@sap/xssec/-/xssec-4.13.3.tgz",
+      "integrity": "sha512-op5wFTpJGJFdwFcEFRDX30yKbB2Kknk+LJqXDcrHyPNLqvSqerTWXFdFnylhiIhoAdGFSccC6NimUhqFxIrUsA==",
+      "license": "SAP DEVELOPER LICENSE AGREEMENT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "jwt-decode": "^4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
+      "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
@@ -82,6 +261,47 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -93,6 +313,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -126,19 +358,54 @@
         }
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/body-parser": {
@@ -163,6 +430,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -197,6 +470,61 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/combined-stream": {
@@ -245,6 +573,12 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -320,10 +654,25 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -410,6 +759,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -465,6 +815,15 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -502,6 +861,12 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -522,16 +887,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
+    },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -708,6 +1080,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -749,10 +1134,33 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/jks-js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/jks-js/-/jks-js-1.1.7.tgz",
+      "integrity": "sha512-BeiDRKsAi1NwEwgx2JB/9/0tar5BNGIv+foGm1G5GgiyR35s/iUnfd/BWqYd16mLDD8qTaAVBrIcOOuVqXJZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "^1.4.0",
+        "node-int64": "^0.4.0",
+        "node-rsa": "^1.1.1"
+      }
     },
     "node_modules/jose": {
       "version": "6.2.2",
@@ -771,6 +1179,123 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -835,6 +1360,42 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT"
+    },
+    "node_modules/node-rsa": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-1.1.1.tgz",
+      "integrity": "sha512-Jd4cvbJMryN21r5HgxQOpMEqv+ooke/korixNNK3mGqfGJmy0M77WDDzo/05969+OkMy3XW1UuZsSmW9KQm7Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "^0.2.4"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -871,6 +1432,24 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/opossum": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/opossum/-/opossum-10.0.0.tgz",
+      "integrity": "sha512-sghtqL8Usj+et06Zui0nyn0R6FFsl7cyuoU+d7MctYU0nbS7Htzjleh+tWohFqk1Rp1srrFwbFa8Vxd0O64w6A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^26 || ^24 || ^22"
       }
     },
     "node_modules/parseurl": {
@@ -919,9 +1498,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/qs": {
       "version": "6.15.0",
@@ -959,12 +1542,35 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/router": {
@@ -982,10 +1588,51 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -1122,12 +1769,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/strnum": {
@@ -1141,12 +1806,27 @@
         }
       ]
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/type-is": {
@@ -1189,6 +1869,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1196,6 +1882,26 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/voca": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/voca/-/voca-1.4.1.tgz",
+      "integrity": "sha512-NJC/BzESaHT1p4B5k4JykxedeltmNbau4cummStd4RjFojgq/kLew5TzYge9N2geeWyI2w8T30wUET5v+F7ZHA==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -1209,6 +1915,42 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {
-    "@arc-mcp/xsuaa-auth": "^0.1.8",
+    "@arc-mcp/xsuaa-auth": "^1.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.7.0",
     "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/index.js",
   "bin": {
-    "bw-modeling-mcp": "dist/index.js"
+    "bw-modeling-mcp": "dist/stdio.js"
   },
   "files": [
     "dist/",
@@ -14,7 +14,7 @@
     "CHANGELOG.md"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "keywords": [
     "sap",
@@ -27,15 +27,21 @@
   ],
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js",
-    "dev": "tsc && node dist/index.js"
+    "start": "node dist/stdio.js",
+    "dev": "tsc && node dist/stdio.js",
+    "start:http": "node dist/http.js",
+    "typecheck": "tsc --noEmit",
+    "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@arc-mcp/xsuaa-auth": "^0.1.8",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "axios": "^1.7.0",
+    "express": "^5.2.1",
     "fast-xml-parser": "^4.3.0"
   },
   "devDependencies": {
+    "@types/express": "^5.0.6",
     "@types/node": "^20.0.0",
     "typescript": "^5.0.0"
   },

--- a/src/bw-client.ts
+++ b/src/bw-client.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import https from 'https';
 import { randomUUID } from 'crypto';
 import * as fs from 'fs';
+import { currentClient } from './request-context.js';
 
 const ECLIPSE_USER_AGENT =
   'Eclipse/4.38.0.v20251201-0920 (win32; x86_64; Java 21.0.9) ADT/3.56.0 (devedition)';
@@ -41,6 +42,37 @@ export interface GetResult {
   headers: Record<string, string>;
 }
 
+/** Cloud Connector hop. The token expires, so it is resolved per request. */
+export interface BwProxyConfig {
+  host: string;
+  port: number;
+  /** Connectivity-service token, sent as `Proxy-Authorization: Bearer …`. */
+  token: string;
+  /** `SAP-Connectivity-SCC-Location_ID`, when several Cloud Connectors serve the subaccount. */
+  locationId?: string;
+}
+
+/**
+ * How a client authenticates to BW.
+ *
+ * `pp` is BTP principal propagation: the Destination service returns a value that the
+ * Cloud Connector converts into a short-lived X.509 certificate for the calling user.
+ * It is deliberately a separate variant rather than an extra optional field, so a
+ * per-user client cannot also carry a shared credential.
+ */
+export type BwAuth =
+  | { kind: 'basic'; user: string; password: string }
+  | { kind: 'cookies'; cookies: Record<string, string> }
+  | { kind: 'pp'; connectivityAuth: string };
+
+export interface BwClientOptions {
+  url: string;
+  auth: BwAuth;
+  client?: string;
+  language?: string;
+  proxy?: BwProxyConfig;
+}
+
 export class BwClient {
   private http: AxiosInstance;
   private csrfToken: string | null = null;
@@ -58,30 +90,33 @@ export class BwClient {
   private readonly sessionDebug: boolean =
     process.env.BW_DEBUG_SESSION === '1' || process.env.BW_DEBUG_SESSION === 'true';
 
-  constructor(
-    url: string,
-    user: string | null,
-    password: string | null,
-    client: string,
-    language?: string,
-    initialCookies?: Record<string, string>
-  ) {
-    this.basicAuth = (user && password)
-      ? 'Basic ' + Buffer.from(`${user}:${password}`).toString('base64')
+  private readonly opts: BwClientOptions;
+
+  constructor(opts: BwClientOptions) {
+    this.opts = opts;
+    this.basicAuth = opts.auth.kind === 'basic'
+      ? 'Basic ' + Buffer.from(`${opts.auth.user}:${opts.auth.password}`).toString('base64')
       : null;
 
     // In cookie mode (e.g. BW Bridge): do not send sap-client and X-sap-adt-sessiontype
     // as global defaults. BW Bridge rejects stateful requests with 401 when no
     // pre-established backend session exists on the app instance pointed to by __VCAP_ID__.
-    const isCookieMode = initialCookies !== undefined;
+    const isCookieMode = opts.auth.kind === 'cookies';
     this.http = axios.create({
-      baseURL: url,
+      baseURL: opts.url,
+      // Cloud Connector: standard absolute-URI proxying. Note the destination URL must
+      // be http:// — an https:// target makes axios tunnel with CONNECT, which drops the
+      // Proxy-Authorization and SAP-Connectivity-Authentication headers, and the
+      // connectivity proxy answers 405.
+      proxy: opts.proxy
+        ? { host: opts.proxy.host, port: opts.proxy.port, protocol: 'http' }
+        : false,
       headers: {
         ...(isCookieMode ? {} : {
-          'sap-client': client,
+          ...(opts.client ? { 'sap-client': opts.client } : {}),
           'X-sap-adt-sessiontype': 'stateful',
         }),
-        ...(language ? { 'sap-language': language } : {}),
+        ...(opts.language ? { 'sap-language': opts.language } : {}),
       },
       httpsAgent: new https.Agent({ rejectUnauthorized: false }),
       validateStatus: () => true,
@@ -89,15 +124,62 @@ export class BwClient {
     delete this.http.defaults.headers.post['Content-Type'];
     delete (this.http.defaults.headers as any).common['Content-Type'];
 
+    // Proxy credentials belong on every request, unlike the identity header — the
+    // connectivity proxy authorizes each hop individually. An interceptor keeps that
+    // out of the ~20 individual request methods.
+    if (opts.proxy) {
+      const proxy = opts.proxy;
+      this.http.interceptors.request.use((config) => {
+        config.headers.set('Proxy-Authorization', `Bearer ${proxy.token}`);
+        if (proxy.locationId) config.headers.set('SAP-Connectivity-SCC-Location_ID', proxy.locationId);
+        return config;
+      });
+    }
+
     // Cookie mode: pre-populate cookie store from caller. Used for SAML/OAuth-fronted
     // systems where Basic Auth is not available and cookies are exported from a browser.
-    if (initialCookies) {
-      for (const [name, value] of Object.entries(initialCookies)) {
+    if (opts.auth.kind === 'cookies') {
+      for (const [name, value] of Object.entries(opts.auth.cookies)) {
         this.cookies.set(name, value);
         // Names from the cookie file are frozen — set-cookie responses must not overwrite them.
         this.frozenCookies.add(name);
       }
     }
+  }
+
+  /**
+   * A second client against the same system with the same identity, but its own
+   * session — empty cookie jar, no CSRF token.
+   *
+   * This is what the existing "fresh session" call sites need: BW keeps a per-session
+   * model buffer, so a session that has written an object serves stale reads afterwards.
+   * Cloning rather than rebuilding from the environment is what lets those call sites
+   * work unchanged under principal propagation, where there is no ambient credential
+   * to rebuild from.
+   */
+  freshSession(): BwClient {
+    return new BwClient(this.opts);
+  }
+
+  /**
+   * The identity credential, applied exactly where this client already sent Basic Auth
+   * — i.e. only on the session-establishing CSRF fetch.
+   *
+   * That placement is deliberate and load-bearing: re-sending a credential on a PUT
+   * makes SAP open a new stateless session and invalidates the lock handle (see the
+   * note on `basicAuth`). Principal propagation follows the same rule, so
+   * `SAP-Connectivity-Authentication` establishes the session and the session cookie
+   * carries it from there.
+   *
+   * `Authorization` is never sent under principal propagation — SAP reserves it for
+   * basic auth to the backend, and sending it breaks identity propagation.
+   */
+  private authHeaders(): Record<string, string> {
+    if (this.basicAuth) return { Authorization: this.basicAuth };
+    if (this.opts.auth.kind === 'pp') {
+      return { 'SAP-Connectivity-Authentication': this.opts.auth.connectivityAuth };
+    }
+    return {};
   }
 
   // ── Session info (debug) ──────────────────────────────────────────────────
@@ -166,7 +248,7 @@ export class BwClient {
       headers: {
         'X-CSRF-Token': 'Fetch',
         Accept: 'application/xml',
-        ...(this.basicAuth ? { Authorization: this.basicAuth } : {}),
+        ...this.authHeaders(),
         ...this.cookieHeaders(),
       },
       responseType: 'text',
@@ -565,7 +647,7 @@ export class BwClient {
     const cookieHdr = this.cookieHeader();
     const response = await freshHttp.post(url, body, {
       headers: {
-        ...(this.basicAuth ? { Authorization: this.basicAuth } : {}),
+        ...this.authHeaders(),
         ...(cookieHdr ? { Cookie: cookieHdr } : {}),
         ...headers,
       },
@@ -629,7 +711,7 @@ export class BwClient {
     const cookieHdr = this.cookieHeader();
     const response = await freshHttp.put(url, body, {
       headers: {
-        ...(this.basicAuth ? { Authorization: this.basicAuth } : {}),
+        ...this.authHeaders(),
         ...(cookieHdr ? { Cookie: cookieHdr } : {}),
         ...headers,
       },
@@ -663,7 +745,7 @@ export class BwClient {
     const cookieHdr = this.cookieHeader();
     const response = await freshHttp.delete(url, {
       headers: {
-        ...(this.basicAuth ? { Authorization: this.basicAuth } : {}),
+        ...this.authHeaders(),
         ...(cookieHdr ? { Cookie: cookieHdr } : {}),
         'x-csrf-token': csrfToken,
         ...headers,
@@ -690,7 +772,7 @@ export class BwClient {
     const response = await this.http.get('/sap/bw/modeling/discovery', {
       headers: {
         Accept: 'application/atomsvc+xml',
-        ...(this.basicAuth ? { Authorization: this.basicAuth } : {}),
+        ...this.authHeaders(),
         ...this.cookieHeaders(),
       },
       responseType: 'text',
@@ -886,7 +968,26 @@ export class BwClient {
   }
 }
 
+/**
+ * A client for the current caller.
+ *
+ * Under the HTTP transport a per-request client is already in scope (its identity came
+ * from XSUAA and, for a principal-propagation destination, from the Destination
+ * service). This returns a fresh *session* on that same identity, which is exactly what
+ * the ~30 existing call sites want — they call this to escape BW's per-session model
+ * buffer, not to pick up credentials.
+ *
+ * Under stdio there is no request context and this reads the environment, unchanged.
+ *
+ * Keeping the signature means no tool file had to be touched for principal propagation.
+ */
 export function createClientFromEnv(): BwClient {
+  const active = currentClient();
+  if (active) return active.freshSession();
+  return clientFromEnvironment();
+}
+
+function clientFromEnvironment(): BwClient {
   const url = process.env.BW_URL;
   const client = process.env.BW_CLIENT ?? '001';
   const language = process.env.BW_LANGUAGE;
@@ -928,9 +1029,7 @@ export function createClientFromEnv(): BwClient {
         `BW_COOKIE_FILE at ${cookieFile} contains no parseable cookies (expected Netscape or name=value format).`
       );
     }
-    const userOpt = process.env.BW_USER ?? null;
-    const passwordOpt = process.env.BW_PASSWORD ?? null;
-    return new BwClient(url, userOpt, passwordOpt, client, language, cookies);
+    return new BwClient({ url, client, language, auth: { kind: 'cookies', cookies } });
   }
 
   // Basic Auth mode: classic on-premise BW/4HANA — unchanged from previous behavior.
@@ -941,7 +1040,7 @@ export function createClientFromEnv(): BwClient {
       'Required environment variables missing: BW_URL, BW_USER, BW_PASSWORD'
     );
   }
-  return new BwClient(url, user, password, client, language);
+  return new BwClient({ url, client, language, auth: { kind: 'basic', user, password } });
 }
 
 /**

--- a/src/destination.ts
+++ b/src/destination.ts
@@ -1,0 +1,140 @@
+/**
+ * Build a BW client from a BTP destination.
+ *
+ * Two destination styles are supported, chosen by the destination itself:
+ *
+ *   Authentication=PrincipalPropagation — per-user. The caller's JWT is exchanged at
+ *     the Destination service for a value the Cloud Connector turns into a short-lived
+ *     X.509 certificate, so BW sees the actual person and applies their own
+ *     authorizations.
+ *
+ *   Authentication=BasicAuthentication — shared. The destination carries one technical
+ *     user; every caller reaches BW as that user. Simpler to set up, but BW cannot tell
+ *     callers apart, so the MCP scopes are the only per-user control.
+ *
+ * Both may run through the Cloud Connector (ProxyType=OnPremise) or connect directly.
+ */
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { BTPConfig, BTPProxyConfig, Destination } from '@arc-mcp/xsuaa-auth/btp';
+import { BwClient, type BwProxyConfig } from './bw-client.js';
+
+export interface DestinationDeps {
+  btpConfig: BTPConfig;
+  proxy?: BTPProxyConfig;
+  destinationName: string;
+}
+
+/**
+ * Through the Cloud Connector the destination URL must be http://.
+ *
+ * SAP: "the call from the cloud application must always use HTTP. If HTTPS is used, a
+ * 405 response will be returned." Independently, an https:// target makes the HTTP
+ * client tunnel with CONNECT, which silently drops both the proxy and identity headers
+ * — so the 405 arrives with nothing pointing at the real cause. The Cloud Connector
+ * still uses HTTPS to reach BW.
+ */
+export function assertProxyableUrl(url: string, destinationName: string): void {
+  if (!url.startsWith('http://')) {
+    throw new Error(
+      `Destination '${destinationName}' has URL '${url}', but Cloud Connector routing requires http://. ` +
+        'An https:// destination makes the HTTP client tunnel via CONNECT, which drops the ' +
+        'principal-propagation headers and returns 405. Use the http:// virtual host here — ' +
+        'the Cloud Connector still reaches BW over HTTPS.',
+    );
+  }
+}
+
+async function resolveProxy(
+  destination: Destination,
+  deps: DestinationDeps,
+): Promise<BwProxyConfig | undefined> {
+  // Only on-premise destinations tunnel through the Cloud Connector. Routing an
+  // internet destination through it would be wrong, not merely slower.
+  if (destination.ProxyType !== 'OnPremise' || !deps.proxy) return undefined;
+  assertProxyableUrl(destination.URL, deps.destinationName);
+  return {
+    host: deps.proxy.host,
+    port: deps.proxy.port,
+    token: await deps.proxy.getProxyToken(),
+    // The destination's own location id wins: with several Cloud Connectors on one
+    // subaccount, reusing the startup one routes to the wrong connector.
+    locationId: destination.CloudConnectorLocationId ?? deps.proxy.locationId,
+  };
+}
+
+function baseOptions(destination: Destination) {
+  return {
+    url: destination.URL,
+    // `sap-client` is not a documented destination property, but destinations commonly
+    // carry it and it is the natural place for it. Environment wins if both are set.
+    client: process.env.BW_CLIENT ?? destination['sap-client'],
+    language: process.env.BW_LANGUAGE ?? (destination.originalProperties?.['sap-language'] as string | undefined),
+  };
+}
+
+/** Per-user client via principal propagation. Fails closed — never returns a shared identity. */
+export async function createPrincipalPropagationClient(
+  deps: DestinationDeps,
+  authInfo: AuthInfo | undefined,
+): Promise<BwClient> {
+  const token = authInfo?.token;
+  if (!token || token.split('.').length !== 3) {
+    throw new Error(
+      'Principal propagation requires a JWT bearer token; the request carried none (or an opaque token).',
+    );
+  }
+
+  const { lookupDestinationWithUserToken } = await import('@arc-mcp/xsuaa-auth/btp');
+  const { destination, authTokens } = await lookupDestinationWithUserToken(
+    deps.btpConfig,
+    deps.destinationName,
+    token,
+  );
+
+  // The lookup populates sapConnectivityAuth; it never sets ppProxyAuth, which is
+  // reserved for consumers implementing the newer jwt-bearer exchange themselves.
+  const connectivityAuth = authTokens.sapConnectivityAuth;
+  if (!connectivityAuth) {
+    throw new Error(
+      `Principal propagation failed for destination '${deps.destinationName}': the Destination service ` +
+        'returned no SAP-Connectivity-Authentication header. Check that the destination has ' +
+        'Authentication=PrincipalPropagation, that the Cloud Connector is connected, and that the ' +
+        'issuing identity provider is trusted and synchronized in the Cloud Connector.',
+    );
+  }
+
+  return new BwClient({
+    ...baseOptions(destination),
+    auth: { kind: 'pp', connectivityAuth },
+    proxy: await resolveProxy(destination, deps),
+  });
+}
+
+/** Shared client from a BasicAuthentication destination. Every caller reaches BW as one user. */
+export async function createSharedDestinationClient(deps: DestinationDeps): Promise<BwClient> {
+  const { lookupDestination } = await import('@arc-mcp/xsuaa-auth/btp');
+  const destination = await lookupDestination(deps.btpConfig, deps.destinationName);
+  if (!destination.User || !destination.Password) {
+    throw new Error(
+      `Destination '${deps.destinationName}' has Authentication=${destination.Authentication} but carries no ` +
+        'user and password. Use BasicAuthentication with credentials, or PrincipalPropagation for per-user access.',
+    );
+  }
+  return new BwClient({
+    ...baseOptions(destination),
+    auth: { kind: 'basic', user: destination.User, password: destination.Password },
+    proxy: await resolveProxy(destination, deps),
+  });
+}
+
+/** Human-readable caller, for logs. The JWT was already verified by the bearer middleware. */
+export function userLabel(authInfo: AuthInfo | undefined): string {
+  const token = authInfo?.token;
+  if (!token) return 'anonymous';
+  try {
+    const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+    return payload.user_name ?? payload.email ?? payload.sub ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * HTTP entry point — SAP BTP Cloud Foundry.
+ *
+ * Adds an authenticated, multi-user front end to the same tools stdio exposes:
+ *
+ *   XSUAA decides who may call this server, and whether they may write
+ *     (`read` / `write` scopes, mapped to two role collections).
+ *   The BTP destination decides who they are to BW. With
+ *     Authentication=PrincipalPropagation each caller reaches BW as themselves and
+ *     BW applies their own authorizations; with BasicAuthentication everyone shares
+ *     the destination's technical user and the MCP scopes are the only per-user control.
+ *
+ * stdio is untouched — no auth, no destination, one process one user.
+ */
+import express from 'express';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import { setupHttpAuth, loadXsuaaCredentials, resolveAppUrl } from '@arc-mcp/xsuaa-auth';
+import { createConnectivityProxy, parseVCAPServices } from '@arc-mcp/xsuaa-auth/btp';
+import { createServer } from './index.js';
+import { runWithClient } from './request-context.js';
+import {
+  createPrincipalPropagationClient,
+  createSharedDestinationClient,
+  userLabel,
+  type DestinationDeps,
+} from './destination.js';
+
+const log = {
+  debug: (m: string, x?: unknown) => process.stderr.write(`[debug] ${m} ${x ? JSON.stringify(x) : ''}\n`),
+  info: (m: string, x?: unknown) => process.stderr.write(`[info] ${m} ${x ? JSON.stringify(x) : ''}\n`),
+  warn: (m: string, x?: unknown) => process.stderr.write(`[warn] ${m} ${x ? JSON.stringify(x) : ''}\n`),
+  error: (m: string, x?: unknown) => process.stderr.write(`[error] ${m} ${x ? JSON.stringify(x) : ''}\n`),
+};
+
+async function main(): Promise<void> {
+  const port = Number(process.env.PORT ?? 8080);
+  const destinationName = process.env.BW_BTP_DESTINATION;
+  if (!destinationName) {
+    throw new Error('BW_BTP_DESTINATION is required for the HTTP transport (the BTP destination pointing at BW).');
+  }
+
+  // Principal propagation is opt-in, because it needs Cloud Connector and ABAP-side
+  // setup (CERTRULE, ICM trust) that a BasicAuthentication destination does not.
+  const ppEnabled = process.env.BW_PP_ENABLED === 'true';
+
+  if (ppEnabled && (process.env.BW_USER || process.env.BW_PASSWORD || process.env.BW_COOKIE_FILE)) {
+    // A shared BW session would win: BW ties the session to whoever opened it, so one
+    // leftover credential turns every per-user request into that user's session, and
+    // nothing in the logs would show it.
+    throw new Error(
+      'BW_PP_ENABLED=true together with BW_USER / BW_PASSWORD / BW_COOKIE_FILE. A shared BW session ' +
+        'silently overrides per-user identity — unset them; the HTTP transport takes credentials from the destination.',
+    );
+  }
+
+  const btpConfig = parseVCAPServices(process.env, log);
+  if (!btpConfig) {
+    throw new Error(
+      'No BTP service bindings found in VCAP_SERVICES. Bind a destination service instance ' +
+        '(and a connectivity instance if BW is on-premise behind the Cloud Connector).',
+    );
+  }
+  // Null when no connectivity binding exists, which is correct for an internet-reachable
+  // BW. Whether the proxy is actually needed depends on the destination's ProxyType.
+  const proxy = createConnectivityProxy(btpConfig, process.env.BW_CC_LOCATION_ID, log) ?? undefined;
+  const deps: DestinationDeps = { btpConfig, proxy, destinationName };
+
+  const app = express();
+  app.use(express.json({ limit: '4mb' }));
+  app.use(express.urlencoded({ extended: true }));
+
+  const bearer = setupHttpAuth(
+    app,
+    {
+      xsuaa: {
+        credentials: loadXsuaaCredentials(),
+        appUrl: resolveAppUrl(process.env, { publicUrlEnvVar: 'BW_PUBLIC_URL', port }),
+        clientIdPrefix: 'bwmcp-',
+        resourceName: 'SAP BW Modeling MCP',
+        requiredScopes: ['read'],
+      },
+      allowedOrigins: process.env.BW_ALLOWED_ORIGINS?.split(',').map((s) => s.trim()).filter(Boolean),
+      // Never start open: an unauthenticated MCP server in front of a Cloud Connector
+      // is a tunnel into the corporate network.
+      required: true,
+    },
+    log,
+  );
+
+  app.get('/health', (_req, res) => {
+    res.status(200).json({ status: 'ok', transport: 'http-streamable', principalPropagation: ppEnabled });
+  });
+
+  app.all('/mcp', bearer!, async (req, res) => {
+    const authInfo = (req as unknown as { auth?: AuthInfo }).auth;
+    let client;
+    try {
+      client = ppEnabled
+        ? await createPrincipalPropagationClient(deps, authInfo)
+        : await createSharedDestinationClient(deps);
+    } catch (err) {
+      // Fail closed. A principal-propagation failure must never quietly fall back to a
+      // shared identity — an error is the only safe outcome.
+      const message = err instanceof Error ? err.message : String(err);
+      log.error('could not build BW client', { user: userLabel(authInfo), destination: destinationName, message });
+      res.status(502).json({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: `Could not connect to BW: ${message}` },
+        id: null,
+      });
+      return;
+    }
+
+    // Stateless: a fresh Server and transport per request. The SDK binds a Server to one
+    // transport for its lifetime, so a shared instance fails after the first call. Per
+    // request also means no protocol state survives between two callers.
+    const server = createServer();
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    res.on('close', () => {
+      void transport.close();
+      void server.close();
+    });
+    await runWithClient(client, async () => {
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    });
+  });
+
+  app.listen(port, () => {
+    process.stderr.write(
+      `bw-modeling-mcp listening on :${port} — destination '${destinationName}'` +
+        `${ppEnabled ? ' with principal propagation' : ' (shared technical user)'}\n`,
+    );
+  });
+}
+
+main().catch((err) => {
+  process.stderr.write(`Fatal error: ${err}\n`);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,11 @@ import {
   ListToolsRequestSchema,
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 
-import { createClientFromEnv } from './bw-client.js';
+import { createClientFromEnv, type BwClient } from './bw-client.js';
+import { currentClient } from './request-context.js';
+import { filterToolsByScope, hasScope, requiredScope } from './scopes.js';
 import { bwGetAdso, bwCreateAdso, FieldDef, bwUpdateAdso, bwUpdateAdsoAddPureField, bwUpdateAdsoSettings, AdsoSettings, bwUpdateAdsoManageKeys, bwUpdateAdsoFieldProperties, FieldProperties } from './tools/adso.js';
 import { bwGetInfoObject, bwCreateInfoObject, bwUpdateInfoObject, AttributeDef } from './tools/infoobject.js';
 import { bwGetTransformation, bwUpdateTransformation, bwCreateTransformation, bwSetTransformationRuntime, bwSetTransformationRoutine, bwDeleteTransformationRoutine, bwSetTransformationRoutineFields, bwSetTransformationExpertRoutine } from './tools/transformation.js';
@@ -38,14 +41,6 @@ import { bwListProcessChainRuns, bwGetProcessChainRunDetail, bwListProcessChainL
 import { bwCreateProcessChain, bwUpdateProcessChain, bwActivateProcessChain, bwAddProcessChainErrorLinks, bwSwapProcessChainDtp, bwAppendProcessChainDtp, bwCreateDecisionVariant, CreateProcessChainParams, UpdateProcessChainParams, EdgeDef, TriggerEventConfig } from './tools/processchain_write.js';
 import { bwCreateTransportTask } from './tools/transport.js';
 
-// Single shared client instance (CSRF token + session cookies are reused)
-const client = createClientFromEnv();
-
-const server = new Server(
-  { name: 'bw-modeling-mcp', version: '0.1.0' },
-  { capabilities: { tools: {} } }
-);
-
 // Map the snake_case trigger_event tool argument to the TriggerEventConfig shape.
 function mapTriggerEvent(raw: unknown): TriggerEventConfig | undefined {
   if (!raw || typeof raw !== 'object') return undefined;
@@ -61,8 +56,7 @@ function mapTriggerEvent(raw: unknown): TriggerEventConfig | undefined {
 
 // ── Tool definitions ─────────────────────────────────────────────────────────
 
-server.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: [
+const TOOL_DEFINITIONS = [
     {
       name: 'bw_search',
       description:
@@ -3345,15 +3339,27 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
         required: ['transport_request', 'user'],
       },
     },
-  ],
-}));
+];
 
 // ── Tool handlers ─────────────────────────────────────────────────────────────
 
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
+async function handleToolCall(
+  request: { params: { name: string; arguments?: Record<string, unknown> } },
+  extra: { authInfo?: AuthInfo },
+): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> {
   const { name, arguments: args } = request.params;
 
+  // Deny before doing any work. stdio has no authInfo and nothing to check.
+  if (!hasScope(extra.authInfo, requiredScope(name))) {
+    throw new McpError(ErrorCode.InvalidRequest, `Tool '${name}' requires the '${requiredScope(name)}' scope.`);
+  }
+
+  // HTTP: the per-request client, whose identity came from XSUAA and the destination.
+  // stdio: no request context, so read the environment exactly as before.
+  const client = currentClient() ?? createClientFromEnv();
+
   try {
+    await ensureMediaTypes(client);
     let text: string;
 
     switch (name) {
@@ -4247,23 +4253,60 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       isError: true,
     };
   }
-});
+}
 
-// ── Start ─────────────────────────────────────────────────────────────────────
+// ── Server ────────────────────────────────────────────────────────────────────
 
-async function main(): Promise<void> {
-  try {
-    await client.loadMediaTypes();
-  } catch (err) {
-    process.stderr.write(`[bw-modeling-mcp] Warning: discovery failed, using hardcoded media type fallbacks (${err})\n`);
+/**
+ * Build an MCP server with every tool registered.
+ *
+ * A factory rather than a module-level instance: the SDK binds a Server to exactly one
+ * transport for its lifetime, so the stateless HTTP transport needs a fresh one per
+ * request. stdio calls this once.
+ */
+export function createServer(): Server {
+  const server = new Server(
+    { name: 'bw-modeling-mcp', version: '0.1.0' },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async (_request, extra) => ({
+    // Hide what the caller may not invoke, so a model never proposes a denied call.
+    tools: filterToolsByScope(TOOL_DEFINITIONS, extra.authInfo),
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, handleToolCall);
+
+  return server;
+}
+
+/**
+ * Populate MEDIA_TYPES on first use rather than at startup.
+ *
+ * The HTTP transport has no credentials at boot — they arrive with the request — so
+ * discovery cannot run there. The type->MIME map is system metadata, identical for every
+ * caller, so one process-wide cache is correct.
+ *
+ * Cleared on failure: otherwise one transient error during the very first request would
+ * leave the fallbacks in place for the life of the process, and later reads would fail
+ * with a misleading "object type not supported on this system".
+ */
+let discovery: Promise<void> | null = null;
+export function ensureMediaTypes(client: BwClient): Promise<void> {
+  if (!discovery) {
+    discovery = client.loadMediaTypes().catch((err) => {
+      discovery = null;
+      process.stderr.write(`[bw-modeling-mcp] Warning: discovery failed, using hardcoded media type fallbacks (${err})\n`);
+    });
   }
+  return discovery;
+}
+
+// ── Start (stdio) ─────────────────────────────────────────────────────────────
+
+export async function startStdio(): Promise<void> {
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  await createServer().connect(transport);
   // Log to stderr only (stdout is used for MCP protocol messages)
   process.stderr.write('bw-modeling-mcp server started\n');
 }
-
-main().catch((err) => {
-  process.stderr.write(`Fatal error: ${err}\n`);
-  process.exit(1);
-});

--- a/src/request-context.ts
+++ b/src/request-context.ts
@@ -1,0 +1,25 @@
+/**
+ * Request-scoped BW client, used by the HTTP transport.
+ *
+ * Under principal propagation the client carries one user's identity, so it cannot be
+ * a module-level singleton. Rather than thread a parameter through every tool and
+ * helper, the active client lives in an AsyncLocalStorage for the duration of the
+ * request. `createClientFromEnv()` consults it (see bw-client.ts), which is what lets
+ * the ~30 existing in-tool "fresh session" call sites keep working unchanged while
+ * still running as the calling user.
+ *
+ * stdio does not use this: there is one process, one user, one set of credentials.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { BwClient } from './bw-client.js';
+
+const storage = new AsyncLocalStorage<BwClient>();
+
+export function runWithClient<T>(client: BwClient, fn: () => Promise<T>): Promise<T> {
+  return storage.run(client, fn);
+}
+
+/** The active request's client, or undefined under stdio. */
+export function currentClient(): BwClient | undefined {
+  return storage.getStore();
+}

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -1,0 +1,97 @@
+/**
+ * Scope enforcement for the HTTP transport.
+ *
+ * Two scopes, matching the two role collections:
+ *   read  — the 41 tools that only read (including `bw_query_data` and
+ *           `bw_preview_datasource`, which return rows but change nothing).
+ *   write — the 42 tools that create, update, delete, activate, push, run, or unlock.
+ *           `write` implies `read`.
+ *
+ * The READ set is the explicit one, and anything unrecognised requires `write`. That
+ * direction matters: a tool added later without touching this file is unavailable to
+ * read-only callers rather than silently offered to them. The opposite arrangement —
+ * listing the writes — would default a new mutating tool to `read`.
+ *
+ * Classification comes from the HTTP verb each implementation actually uses, not from
+ * the tool name: `bw_query_data` and `bw_preview_datasource` issue POSTs but only read,
+ * while `bw_unlock` looks harmless and mutates server-side lock state.
+ *
+ * This gates who may call the server. What a caller can actually see or change in BW is
+ * decided by BW, against the ABAP user behind the request — under principal propagation
+ * that is the caller themselves. Scopes restrict; they never widen.
+ *
+ * stdio has no authInfo and therefore no scopes: whoever runs the process already holds
+ * the credentials.
+ */
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+
+export type Scope = 'read' | 'write';
+
+const READ_TOOLS = new Set([
+  'bw_get_adso',
+  'bw_get_aggregation_level',
+  'bw_get_ckf',
+  'bw_get_composite_provider',
+  'bw_get_dataflow',
+  'bw_get_datasource',
+  'bw_get_dtp',
+  'bw_get_dtps',
+  'bw_get_filter_values',
+  'bw_get_infoarea',
+  'bw_get_infoobject',
+  'bw_get_infosource',
+  'bw_get_open_hub',
+  'bw_get_planning_function',
+  'bw_get_planning_properties',
+  'bw_get_planning_sequence',
+  'bw_get_process_chain',
+  'bw_get_process_chain_run_detail',
+  'bw_get_process_variant',
+  'bw_get_push_schema',
+  'bw_get_query',
+  'bw_get_query_roles',
+  'bw_get_request',
+  'bw_get_rkf',
+  'bw_get_role_queries',
+  'bw_get_roles',
+  'bw_get_source_system',
+  'bw_get_structure',
+  'bw_get_transformation',
+  'bw_list_changeable_transports',
+  'bw_list_contents',
+  'bw_list_datasources',
+  'bw_list_process_chain_last_status',
+  'bw_list_process_chain_runs',
+  'bw_list_remote_entities',
+  'bw_list_requests',
+  'bw_list_source_systems',
+  'bw_preview_datasource',
+  'bw_query_data',
+  'bw_search',
+  'bw_xref',
+]);
+
+export function requiredScope(toolName: string): Scope {
+  return READ_TOOLS.has(toolName) ? 'read' : 'write';
+}
+
+/** Accepts bare or XSUAA-qualified scopes (`bwmcp!t123.read`). */
+function has(scopes: readonly string[], scope: Scope): boolean {
+  return scopes.some((s) => s === scope || s.endsWith(`.${scope}`));
+}
+
+export function hasScope(authInfo: AuthInfo | undefined, scope: Scope): boolean {
+  if (!authInfo) return true; // stdio
+  const scopes = authInfo.scopes ?? [];
+  if (has(scopes, scope)) return true;
+  return scope === 'read' && has(scopes, 'write'); // write implies read
+}
+
+/** Hide tools the caller cannot invoke, so a model never proposes a call that will be denied. */
+export function filterToolsByScope<T extends { name: string }>(
+  tools: T[],
+  authInfo: AuthInfo | undefined,
+): T[] {
+  if (!authInfo) return tools;
+  return tools.filter((t) => hasScope(authInfo, requiredScope(t.name)));
+}

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// stdio entry point — local use and desktop MCP clients, unchanged behaviour.
+// For BTP Cloud Foundry with XSUAA, see http.ts.
+import { startStdio } from './index.js';
+
+startStdio().catch((err) => {
+  process.stderr.write(`Fatal error: ${err}\n`);
+  process.exit(1);
+});

--- a/tests/destination.test.mjs
+++ b/tests/destination.test.mjs
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { assertProxyableUrl, createPrincipalPropagationClient, userLabel } from '../dist/destination.js';
+
+test('an https destination behind the Cloud Connector is rejected up front', () => {
+  // Otherwise the HTTP client tunnels with CONNECT, dropping both the proxy and identity
+  // headers, and the connectivity proxy answers 405 with no hint at the real cause.
+  assert.throws(() => assertProxyableUrl('https://bw.internal:44300', 'BW4'), /requires http:\/\//);
+  assert.doesNotThrow(() => assertProxyableUrl('http://bw.internal:8000', 'BW4'));
+});
+
+test('principal propagation requires a JWT', async () => {
+  const deps = { btpConfig: {}, destinationName: 'BW4' };
+  await assert.rejects(() => createPrincipalPropagationClient(deps, undefined), /requires a JWT bearer token/);
+  await assert.rejects(
+    () => createPrincipalPropagationClient(deps, { token: 'opaque', scopes: [], clientId: 'x' }),
+    /requires a JWT bearer token/,
+  );
+});
+
+test('userLabel never throws on a malformed token', () => {
+  assert.equal(userLabel(undefined), 'anonymous');
+  assert.equal(userLabel({ token: 'a.b.c', scopes: [], clientId: 'x' }), 'unknown');
+});

--- a/tests/scopes.test.mjs
+++ b/tests/scopes.test.mjs
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { requiredScope, hasScope, filterToolsByScope } from '../dist/scopes.js';
+
+test('mutating tools require write — including ones whose names do not say so', () => {
+  for (const n of ['bw_create_adso', 'bw_update_query_layout', 'bw_delete', 'bw_activate', 'bw_push_data', 'bw_run_dtp']) {
+    assert.equal(requiredScope(n), 'write', n);
+  }
+  // bw_unlock reads as harmless but mutates server-side lock state.
+  assert.equal(requiredScope('bw_unlock'), 'write');
+});
+
+test('read tools that issue POSTs are still reads', () => {
+  // Both POST, neither changes anything: bw_query_data sends BICS navigation,
+  // bw_preview_datasource posts an empty body to sample rows.
+  assert.equal(requiredScope('bw_query_data'), 'read');
+  assert.equal(requiredScope('bw_preview_datasource'), 'read');
+});
+
+test('an unrecognised tool requires write, so a new tool fails closed', () => {
+  // A tool added later without updating scopes.ts must not be offered to readers.
+  assert.equal(requiredScope('bw_some_future_tool'), 'write');
+  const reader = { token: 't', clientId: 'c', scopes: ['read'] };
+  assert.ok(!hasScope(reader, requiredScope('bw_delete_everything_new')));
+});
+
+test('write implies read; read does not imply write', () => {
+  const w = { token: 't', clientId: 'c', scopes: ['write'] };
+  const r = { token: 't', clientId: 'c', scopes: ['read'] };
+  assert.ok(hasScope(w, 'read'));
+  assert.ok(hasScope(w, 'write'));
+  assert.ok(hasScope(r, 'read'));
+  assert.ok(!hasScope(r, 'write'));
+});
+
+test('XSUAA-qualified scopes are accepted', () => {
+  assert.ok(hasScope({ token: 't', clientId: 'c', scopes: ['bwmcp!t42.write'] }, 'write'));
+});
+
+test('stdio has no authInfo and is unrestricted', () => {
+  assert.ok(hasScope(undefined, 'write'));
+  const tools = [{ name: 'bw_get_adso' }, { name: 'bw_delete' }];
+  assert.equal(filterToolsByScope(tools, undefined).length, 2);
+});

--- a/tests/tool-surface.test.mjs
+++ b/tests/tool-surface.test.mjs
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { requiredScope, filterToolsByScope } from '../dist/scopes.js';
+
+/** Start the stdio server and ask it for its tool list. */
+function listTools() {
+  return new Promise((resolve, reject) => {
+    const srv = spawn('node', ['dist/stdio.js'], {
+      env: { ...process.env, BW_URL: 'http://unused.invalid:8000', BW_USER: 'x', BW_PASSWORD: 'x' },
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+    const send = (m) => srv.stdin.write(JSON.stringify(m) + '\n');
+    send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 't', version: '1' } } });
+    let buf = '';
+    const timer = setTimeout(() => { srv.kill(); reject(new Error('timeout')); }, 20000);
+    srv.stdout.on('data', (d) => {
+      buf += d;
+      const lines = buf.split('\n');
+      buf = lines.pop();
+      for (const l of lines) {
+        if (!l.trim()) continue;
+        const msg = JSON.parse(l);
+        if (msg.id === 1) {
+          send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+          send({ jsonrpc: '2.0', id: 2, method: 'tools/list' });
+        } else if (msg.id === 2) {
+          clearTimeout(timer);
+          srv.kill();
+          resolve(msg.result.tools.map((t) => t.name));
+        }
+      }
+    });
+  });
+}
+
+test('the full tool surface is still registered', async () => {
+  // This change is additive — a transport and an auth layer. It must not alter the
+  // tools stdio users already depend on.
+  const names = await listTools();
+  assert.equal(names.length, 83);
+});
+
+test('every tool is classified, and the split matches the verb audit', async () => {
+  const names = await listTools();
+  const write = names.filter((n) => requiredScope(n) === 'write');
+  assert.equal(write.length, 42);
+  assert.equal(names.length - write.length, 41);
+});
+
+test('a reader is offered only the read tools', async () => {
+  const names = await listTools();
+  const offered = filterToolsByScope(names.map((name) => ({ name })), { token: 't', clientId: 'c', scopes: ['read'] });
+  assert.equal(offered.length, 41);
+  assert.ok(!offered.some((t) => requiredScope(t.name) === 'write'));
+});
+
+test('the MCP server is a per-request factory', async () => {
+  // The SDK binds a Server to one transport for its lifetime; a shared instance throws
+  // "Already connected to a transport" on the second HTTP request.
+  const { createServer } = await import('../dist/index.js');
+  assert.notEqual(createServer(), createServer());
+});

--- a/xs-security.json
+++ b/xs-security.json
@@ -1,0 +1,46 @@
+{
+  "xsappname": "bwmcp",
+  "tenant-mode": "dedicated",
+  "description": "SAP BW Modeling MCP server",
+  "scopes": [
+    { "name": "$XSAPPNAME.read",  "description": "Read BW modeling objects and query data" },
+    { "name": "$XSAPPNAME.write", "description": "Create, change, delete and activate BW objects (implies read)" }
+  ],
+  "role-templates": [
+    {
+      "name": "BWReader",
+      "description": "Read-only access to BW modeling objects via MCP",
+      "scope-references": ["$XSAPPNAME.read"]
+    },
+    {
+      "name": "BWDeveloper",
+      "description": "Full read and write access to BW modeling objects via MCP",
+      "scope-references": ["$XSAPPNAME.read", "$XSAPPNAME.write"]
+    }
+  ],
+  "role-collections": [
+    {
+      "name": "BW MCP Reader",
+      "description": "Read BW modeling objects via MCP. Write tools are not offered.",
+      "role-template-references": ["$XSAPPNAME.BWReader"]
+    },
+    {
+      "name": "BW MCP Developer",
+      "description": "Read and change BW modeling objects via MCP",
+      "role-template-references": ["$XSAPPNAME.BWDeveloper"]
+    }
+  ],
+  "oauth2-configuration": {
+    "redirect-uris": [
+      "https://*.hana.ondemand.com/**",
+      "https://claude.ai/**",
+      "https://claude.com/**",
+      "https://*.anthropic.com/**",
+      "http://localhost:*/**",
+      "vscode://**",
+      "cursor://**"
+    ],
+    "token-validity": 43200,
+    "refresh-token-validity": 604800
+  }
+}


### PR DESCRIPTION
Adds an HTTP transport alongside stdio so the server can run as a shared service on Cloud Foundry: OAuth at the front, a BTP destination at the back. All 83 tools stay, byte-identical, and stdio behaviour is unchanged.

Two destination topologies, chosen by the destination itself:

  Authentication=BasicAuthentication — every caller reaches BW as the destination's
    technical user. Just a destination, no Cloud Connector setup.
  Authentication=PrincipalPropagation + BW_PP_ENABLED=true — the caller's XSUAA JWT
    is exchanged for a value the Cloud Connector turns into a short-lived X.509
    certificate, so BW sees the actual person and applies their own authorizations.

Two role collections: BW MCP Reader (the 41 read tools) and BW MCP Developer (all 83). Out-of-scope tools are filtered from tools/list rather than failing on call, so a model never proposes something that will be denied. Classification follows the HTTP verb each implementation uses, not the tool name — bw_query_data and bw_preview_datasource POST but only read, while bw_unlock sounds harmless and mutates lock state. The read set is the explicit one, so an unclassified new tool requires write rather than being offered to readers.

Kept deliberately small:

- No tool file is touched. The ~30 in-tool createClientFromEnv() calls still work: that function now returns a fresh *session* on the request's client when one is in scope, and reads the environment otherwise. Those call sites want a new session to escape BW's per-session model buffer, not credentials — so cloning satisfies them and carries the caller's identity for free.
- index.ts is +70/-27. The tool array becomes a plain const and the call handler a named function, both keeping their existing indentation, so the diff is the actual change rather than a re-indent of 3,800 lines.
- BwClient keeps its session discipline: the identity header goes exactly where Basic Auth already went (the session-establishing CSRF fetch), because re-sending a credential on a PUT makes SAP open a new stateless session and invalidates the lock handle. Proxy credentials do ride every request — the connectivity proxy authorizes each hop — via one interceptor rather than ~20 edits.

Also: discovery moved to first-request lazy (the HTTP transport has no credentials at boot), clearing its cache on failure so one transient error cannot leave the fallbacks in place for the process lifetime.

BwClient's constructor takes an options object instead of six positional parameters. It is exported, so that is the one breaking API change.

tests/ is in .gitignore as a scratch area; this un-ignores only *.test.mjs so the suite is versioned without claiming the whole directory. Happy to drop them if you would rather keep tests out of the repo.