### PR TITLE
fix: parse OData dates that carry a timezone offset

### DIFF
--- a/src/tools/process_chain_monitor.ts
+++ b/src/tools/process_chain_monitor.ts
@@ -15,7 +15,10 @@ function buildODataUrl(service: string, entitySet: string, opts: {
 
 function odataDateToIso(v: string | undefined): string | undefined {
   if (!v) return undefined;
-  const m = /\/Date\((-?\d+)\)\//.exec(v);
+  // SAP OData V2 emits epoch-ms dates, optionally with a display timezone offset:
+  // `/Date(1784700050000)/` or `/Date(1784700050000+0000)/`. The ms are UTC, so the
+  // offset is ignored for the ISO conversion.
+  const m = /\/Date\((-?\d+)(?:[+-]\d{4})?\)\//.exec(v);
   return m ? new Date(Number(m[1])).toISOString() : v;
 }
 


### PR DESCRIPTION
> **⚠️ AI-generated — requires expert human review before merging.**
> This issue surfaced during automated AI testing against a real SAP BW/4HANA system — **BW/4HANA 2023** (`DW4CORE 400 SP07`, `SAP_BASIS 758 SP04`) — driven through a BW Modeling Tools user. The problem analysis and the code fix were produced entirely by AI — GitHub Copilot (Claude Opus 4.8) — with no human review. The SAP-side behavior claims are the AI's findings, not verified against SAP documentation or Notes. Please have someone with deep SAP BW internals knowledge validate both the diagnosis and the fix before merging.

Process-chain run / last-status timestamps occasionally render as the raw `/Date(…)/` string instead of an ISO date.

`odataDateToIso()` in `src/tools/process_chain_monitor.ts` matches only `/\/Date\((-?\d+)\)\//`, but SAP OData V2 also emits the offset variant `/Date(1734000000000+0000)/`. That form fails the regex and the value falls through unparsed.

**Fix:** tolerate an optional trailing `±HHMM` offset: `/\/Date\((-?\d+)(?:[+-]\d{4})?\)\//`. The epoch ms are UTC, so the offset is display-only and ignored for the conversion.

**Testing:** `npm run build` (tsc) passes; non-offset dates parse identically to before.
