### PR TITLE
fix: return a clear error when a transformation read 500s

### DIFF
--- a/src/tools/transformation.ts
+++ b/src/tools/transformation.ts
@@ -186,7 +186,26 @@ export async function bwGetTransformation(
   transformationName: string,
   format: 'text' | 'raw' = 'text',
 ): Promise<string> {
-  const result = await freshReadInactive(transformationName.toLowerCase());
+  let result: { body: string; headers: Record<string, string> };
+  try {
+    result = await freshReadInactive(transformationName.toLowerCase());
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    // SAP raises HTTP 500 "BW Model serialization failed" (CL_RSO_RES_TRFN → get_xml_from_db)
+    // for transformations the modeling serializer cannot represent — typically ones with
+    // start/end/expert ABAP routines or legacy rule types. It is a permanent SAP modeling-
+    // serializer limitation (Eclipse BWMT shows the same), not a transient error, so surface it
+    // clearly and point to SAP GUI (RSTRAN) instead of leaking the raw 500 + XML body.
+    if (/serialization failed/i.test(msg)) {
+      throw new Error(
+        `Transformation ${transformationName.toUpperCase()} cannot be read via the BW modeling API: ` +
+          'SAP returned "BW Model serialization failed" (HTTP 500). This is a permanent limitation for ' +
+          'transformations whose model the serializer cannot represent (usually start/end/expert ABAP ' +
+          'routines or legacy rule types), not a transient error — inspect it in SAP GUI (RSTRAN) instead.',
+      );
+    }
+    throw e;
+  }
   const status = result.headers['object_status'] ?? result.headers['OBJECT_STATUS'] ?? 'unknown';
   const ts = result.headers['timestamp'] ?? '';
   const xml = result.body;


### PR DESCRIPTION
> **⚠️ AI-generated — requires expert human review before merging.**
> This issue surfaced during automated AI testing against a real SAP BW/4HANA system — **BW/4HANA 2023** (`DW4CORE 400 SP07`, `SAP_BASIS 758 SP04`) — driven through a BW Modeling Tools user. The problem analysis and the code fix were produced entirely by AI — GitHub Copilot (Claude Opus 4.8) — with no human review. The SAP-side behavior claims are the AI's findings, not verified against SAP documentation or Notes. Please have someone with deep SAP BW internals knowledge validate both the diagnosis and the fix before merging.

`GET /sap/bw/modeling/trfn/{name}/m` returns HTTP 500 "BW Model serialization failed" (`CL_RSO_RES_TRFN → get_xml_from_db`) for transformations the modeling serializer cannot represent — typically ones with start/end/expert ABAP routines or legacy rule types. This appears to be a permanent SAP modeling limitation (Eclipse BWMT shows the same on such transformations), not a transient error. `bwGetTransformation()` surfaced the raw 500 plus the full XML body.

**Fix:** catch the "serialization failed" 500 and throw a concise, actionable error pointing to SAP GUI (RSTRAN). Any other error is re-thrown unchanged.

**Reviewer note:** please confirm the "permanent SAP limitation" characterization — it's the AI's inference from observed behavior, not from an SAP Note.

**Testing:** `npm run build` passes.
