### PR TITLE
fix: don't surface the NODESNOTCONNECTED InfoArea sentinel

### DIFF
--- a/src/tools/adso.ts
+++ b/src/tools/adso.ts
@@ -1,5 +1,6 @@
 import { BwClient, MEDIA_TYPES, createClientFromEnv, freshRead } from '../bw-client.js';
 import { parseInfoObjectProps } from './infoobject.js';
+import { stripInfoAreaSentinel } from '../xml.js';
 
 // ── aDSO type presets ────────────────────────────────────────────────────────
 
@@ -188,7 +189,7 @@ function summarizeAdso(adsoName: string, status: string, xml: string): string {
   const desc = rawDesc
     .replace(/&quot;/g, '"').replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&apos;/g, "'");
-  const infoArea = xml.match(/<infoArea>([^<]*)<\/infoArea>/)?.[1] ?? '';
+  const infoArea = stripInfoAreaSentinel(xml.match(/<infoArea>([^<]*)<\/infoArea>/)?.[1] ?? '');
   const pkg = xml.match(/<adtcore:packageRef\b[^>]*\badtcore:name="([^"]*)"/)?.[1] ?? '';
   const objectVersion = xml.match(/<objectVersion>([^<]*)<\/objectVersion>/)?.[1] ?? '';
   const versionMap: Record<string, string> = { M: 'Inactive', A: 'Active' };

--- a/src/tools/composite_provider.ts
+++ b/src/tools/composite_provider.ts
@@ -1,4 +1,5 @@
 import { BwClient } from '../bw-client.js';
+import { stripInfoAreaSentinel } from '../xml.js';
 
 const HCPR_ACCEPT = [
   'application/vnd.sap.bw.modeling.hcpr-v1_0_0+xml',
@@ -46,7 +47,7 @@ export async function bwGetCompositeProvider(
   const responsible = attr(tlogoAttrs, 'adtcore:responsible');
   const changedAt = attr(tlogoAttrs, 'adtcore:changedAt');
   const changedBy = attr(tlogoAttrs, 'adtcore:changedBy');
-  const infoArea = xml.match(/<infoArea>([^<]+)<\/infoArea>/)?.[1] ?? '';
+  const infoArea = stripInfoAreaSentinel(xml.match(/<infoArea>([^<]+)<\/infoArea>/)?.[1] ?? '');
   const packageName = xml.match(/adtcore:packageRef[^>]*adtcore:name="([^"]+)"/)?.[1] ?? '';
 
   // viewNode

--- a/src/tools/cp_components.ts
+++ b/src/tools/cp_components.ts
@@ -1,6 +1,7 @@
 import { XMLParser } from 'fast-xml-parser';
 import { BwClient } from '../bw-client.js';
 import { ckfAccept, rkfAccept, structureAccept } from './query.js';
+import { stripInfoAreaSentinel } from '../xml.js';
 
 // ── XML Parser ───────────────────────────────────────────────────────────────
 
@@ -132,7 +133,7 @@ function extractMetadata(
   const entityProps = (mainComp['Qry:entityProperties'] ?? {}) as Record<string, unknown>;
   const packageRef = entityProps['adtCore:packageRef'] as Record<string, unknown> | undefined;
   const rawInfoArea = entityProps['infoArea'];
-  const infoArea = typeof rawInfoArea === 'string' ? rawInfoArea : '';
+  const infoArea = stripInfoAreaSentinel(typeof rawInfoArea === 'string' ? rawInfoArea : '');
 
   return {
     timestamp: (mainComp['@_timestamp'] as string) ?? '',

--- a/src/tools/infoarea.ts
+++ b/src/tools/infoarea.ts
@@ -1,4 +1,5 @@
 import { BwClient, MEDIA_TYPES } from '../bw-client.js';
+import { stripInfoAreaSentinel } from '../xml.js';
 
 // ── bwMoveObject ──────────────────────────────────────────────────────────────
 
@@ -154,7 +155,7 @@ export async function bwGetInfoarea(client: BwClient, name: string): Promise<str
       parsed['objectStatus'] ??
       '';
 
-    return JSON.stringify({ name: infoAreaName, label, parent_area: parentArea || null, object_status: objectStatus }, null, 2);
+    return JSON.stringify({ name: infoAreaName, label, parent_area: stripInfoAreaSentinel(parentArea ?? '') || null, object_status: objectStatus }, null, 2);
   } catch {
     return JSON.stringify({ raw: body });
   }

--- a/src/tools/infosource.ts
+++ b/src/tools/infosource.ts
@@ -1,4 +1,5 @@
 import { BwClient, MEDIA_TYPES, freshRead } from '../bw-client.js';
+import { stripInfoAreaSentinel } from '../xml.js';
 
 const TRCS_MEDIA = 'application/vnd.sap.bw.modeling.trcs-v1_0_0+xml';
 
@@ -29,7 +30,7 @@ export async function bwGetInfosource(client: BwClient, name: string): Promise<s
   const objectStatus = (tlogoPart.match(/adtcore:version="([^"]*)"/) ?? [])[1] ?? '';
 
   // <infoArea>
-  const infoArea = (xml.match(/<infoArea>([^<]*)<\/infoArea>/) ?? [])[1] ?? '';
+  const infoArea = stripInfoAreaSentinel((xml.match(/<infoArea>([^<]*)<\/infoArea>/) ?? [])[1] ?? '');
 
   // Collect keyElement names: #///NAME → NAME
   const keyElements = new Set<string>();

--- a/src/tools/openhub.ts
+++ b/src/tools/openhub.ts
@@ -1,4 +1,5 @@
 import { BwClient, MEDIA_TYPES } from '../bw-client.js';
+import { stripInfoAreaSentinel } from '../xml.js';
 
 interface OpenHubField {
   name: string;
@@ -66,7 +67,7 @@ function parseOpenHubXml(xml: string, status: string): OpenHubInfo {
   const tlMatch = xml.match(/<tlogoProperties([^>]*)>/);
   const tlAttrs = tlMatch?.[1] ?? '';
   const tlogoPkg = xml.match(/<adtcore:packageRef\b[^>]*\bname="([^"]*)"/)?.[1] ?? '';
-  const infoArea = xml.match(/<infoArea[^>]*>([^<]+)<\/infoArea>/)?.[1]?.trim() ?? '';
+  const infoArea = stripInfoAreaSentinel(xml.match(/<infoArea[^>]*>([^<]+)<\/infoArea>/)?.[1]?.trim() ?? '');
 
   // Key elements — collect the name tokens from #///<name>
   const keyNames = new Set<string>();

--- a/src/tools/planning.ts
+++ b/src/tools/planning.ts
@@ -1,4 +1,5 @@
 import { BwClient, MEDIA_TYPES } from '../bw-client.js';
+import { stripInfoAreaSentinel } from '../xml.js';
 
 function attr(tag: string, attrName: string): string {
   const m = tag.match(new RegExp(`\\b${attrName}="([^"]*)"`));
@@ -88,7 +89,7 @@ function parseAggLevelXml(xml: string, status: string): AggLevelInfo {
   const infoProvider = attr(compositeInputMatch[0], 'name');
 
   const tlogoPkg = xml.match(/<adtcore:packageRef\b[^>]*\bname="([^"]*)"/)?.[1] ?? '';
-  const infoArea = xml.match(/<infoArea[^>]*>([^<]+)<\/infoArea>/)?.[1]?.trim() ?? '';
+  const infoArea = stripInfoAreaSentinel(xml.match(/<infoArea[^>]*>([^<]+)<\/infoArea>/)?.[1]?.trim() ?? '');
 
   // Build dimension name → label map
   const dimensionMap = new Map<string, string>();
@@ -310,7 +311,7 @@ function parsePlcrXml(xml: string, status: string): PlanningPropertiesInfo {
   const tlMatch = xml.match(/<tlogoProperties([^>]*)>/);
   const name = tlMatch ? (attr(tlMatch[1], 'adtcore:name') || providerName) : providerName;
   const tlogoPkg = xml.match(/<adtcore:packageRef\b[^>]*\bname="([^"]*)"/)?.[1] ?? '';
-  const infoArea = xml.match(/<infoArea[^>]*>([^<]+)<\/infoArea>/)?.[1]?.trim() ?? '';
+  const infoArea = stripInfoAreaSentinel(xml.match(/<infoArea[^>]*>([^<]+)<\/infoArea>/)?.[1]?.trim() ?? '');
 
   // atom:link rel="up" — underlying provider's resource URL and media type
   const upLinkMatch = xml.match(/<atom:link\b[^>]*\brel="up"[^>]*>/);
@@ -410,7 +411,7 @@ function parsePlsqXml(xml: string, status: string): PlsqInfo {
 
   const description = xml.match(/<description\b[^>]*\blabel="([^"]*)"/)?.[1] ?? '';
   const tlogoPkg = xml.match(/<adtcore:packageRef\b[^>]*\bname="([^"]*)"/)?.[1] ?? '';
-  const infoArea = xml.match(/<infoArea[^>]*>([^<]+)<\/infoArea>/)?.[1]?.trim() ?? '';
+  const infoArea = stripInfoAreaSentinel(xml.match(/<infoArea[^>]*>([^<]+)<\/infoArea>/)?.[1]?.trim() ?? '');
 
   // Steps are self-closing <step .../> elements; preserve document order
   const steps: PlsqStep[] = [];
@@ -665,7 +666,7 @@ function parsePlseXml(xml: string, status: string): PlseInfo {
 
   const description = xml.match(/<description\b[^>]*\blabel="([^"]*)"/)?.[1] ?? '';
   const tlogoPkg = xml.match(/<adtcore:packageRef\b[^>]*\bname="([^"]*)"/)?.[1] ?? '';
-  const infoArea = xml.match(/<infoArea[^>]*>([^<]+)<\/infoArea>/)?.[1]?.trim() ?? '';
+  const infoArea = stripInfoAreaSentinel(xml.match(/<infoArea[^>]*>([^<]+)<\/infoArea>/)?.[1]?.trim() ?? '');
 
   const charUsages: PlseCharUsage[] = [];
   const cuRe = /<charUsage\b([^>]*)(?:\/>|>[\s\S]*?<\/charUsage>)/g;

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -1,0 +1,9 @@
+/**
+ * SAP returns the sentinel `NODESNOTCONNECTED` as the InfoArea of an object whose node is not
+ * attached to an InfoArea in the requested tree view. It is not a real InfoArea name, so it must
+ * never be surfaced in an object summary. Normalize it to an empty string; every reader that
+ * displays an InfoArea passes its extracted value through this helper.
+ */
+export function stripInfoAreaSentinel(v: string): string {
+  return v === 'NODESNOTCONNECTED' ? '' : v;
+}


### PR DESCRIPTION
> **⚠️ AI-generated — requires expert human review before merging.**
> This issue surfaced during automated AI testing against a real SAP BW/4HANA system — **BW/4HANA 2023** (`DW4CORE 400 SP07`, `SAP_BASIS 758 SP04`) — driven through a BW Modeling Tools user. The problem analysis and the code fix were produced entirely by AI — GitHub Copilot (Claude Opus 4.8) — with no human review. The SAP-side behavior claims are the AI's findings, not verified against SAP documentation or Notes. Please have someone with deep SAP BW internals knowledge validate both the diagnosis and the fix before merging.

SAP returns the sentinel `NODESNOTCONNECTED` as the InfoArea of an object whose node is not attached to an InfoArea in the requested tree view. Every reader that surfaces the InfoArea copied it verbatim, so summaries printed `InfoArea: NODESNOTCONNECTED` (`bw_get_adso`) or emitted `"info_area": "NODESNOTCONNECTED"` (CompositeProvider components, etc.).

**Fix:** add a shared `stripInfoAreaSentinel()` (`src/xml.ts`) that maps the sentinel to an empty string, applied in every reader that extracts an InfoArea: aDSO, CompositeProvider (+ components), InfoSource, Open Hub, InfoArea (parent), and the four Planning readers (Aggregation Level, PLSE, PLSQ, PLCR).

**Testing:** `npm run build` passes.
